### PR TITLE
Bump celery from 3.1.23 to 5.2.2 in /tests/vulnerabilities

### DIFF
--- a/tests/vulnerabilities/requirements.txt
+++ b/tests/vulnerabilities/requirements.txt
@@ -20,7 +20,7 @@ SQLAlchemy==1.0.13
 visitor==0.1.3
 Werkzeug==0.11.9
 ConcurrentLogHandler==0.9.1
-celery==3.1.23
+celery==5.2.2
 pytest==3.0.6
 prettytable==0.7.2
 pip==9.0.1


### PR DESCRIPTION
### Description

In this pull request, the version of the Python package `celery` is being updated from `3.1.23` to `5.2.2` in the `requirements.txt` file located in the vulnerabilities testing directory. This update is being made to keep the project's dependencies up to date with the latest releases.

Changes:
- Update the version of Celery in the `requirements.txt` file from `3.1.23` to `5.2.2`.