### PR TITLE
Bump jinja2 from 2.8 to 2.11.3 in /tests/vulnerabilities

### DIFF
--- a/tests/vulnerabilities/requirements.txt
+++ b/tests/vulnerabilities/requirements.txt
@@ -7,7 +7,7 @@ Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1
 Flask-Cache==0.13.1
 itsdangerous==0.24
-Jinja2==2.8
+Jinja2==2.11.3
 Mako==1.0.4
 MarkupSafe==0.23
 MySQL-python==1.2.5


### PR DESCRIPTION
### Description

The changes in this pull request involve updating the version of Jinja2 library in the requirements.txt file from 2.8 to 2.11.3.

- Update Jinja2 library version in requirements.txt from 2.8 to 2.11.3